### PR TITLE
Update bo page title to "袁博退休倒计时 - 博Fans"

### DIFF
--- a/apps/frontend-astro/src/pages/bo.astro
+++ b/apps/frontend-astro/src/pages/bo.astro
@@ -7,7 +7,7 @@ import Countdown from '../components/tuixiu/countdown.astro';
 ---
 
 <Layout
-  title="博退倒计时 - 袁博退休倒计时"
+  title="袁博退休倒计时 - 博Fans"
   description="距离腾讯云核心产品经理袁博（boyuan）退休还有多少时间？腾讯云lighthouse和DNSPod又该何去何从，让我们拭目以待。"
 >
   <Tuixiu>


### PR DESCRIPTION
### Motivation
- Update the displayed page title to better reflect branding for the Bo retirement countdown page by adjusting the title string.

### Description
- Modified `apps/frontend-astro/src/pages/bo.astro` to change the `title` prop from "博退倒计时 - 袁博退休倒计时" to "袁博退休倒计时 - 博Fans".

### Testing
- No automated tests were added or executed for this trivial UI text change; existing CI will validate build and linters on merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c8a4b1bc8331bd675c67bab06c52)