### PR TITLE
Add BoFans page and image2 asset; update bo page title

### DIFF
--- a/apps/frontend-astro/src/assets/image2.svg
+++ b/apps/frontend-astro/src/assets/image2.svg
@@ -1,0 +1,14 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="640" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1D4ED8"/>
+      <stop offset="1" stop-color="#22C55E"/>
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" rx="24" fill="url(#g)"/>
+  <circle cx="112" cy="96" r="36" fill="white" fill-opacity="0.3"/>
+  <rect x="176" y="76" width="320" height="28" rx="14" fill="white" fill-opacity="0.85"/>
+  <rect x="176" y="120" width="220" height="20" rx="10" fill="white" fill-opacity="0.65"/>
+  <rect x="64" y="188" width="512" height="108" rx="16" fill="white" fill-opacity="0.2"/>
+  <text x="88" y="250" fill="white" font-size="28" font-family="Arial, sans-serif" font-weight="700">BoFans · image2</text>
+</svg>

--- a/apps/frontend-astro/src/pages/bo.astro
+++ b/apps/frontend-astro/src/pages/bo.astro
@@ -7,7 +7,7 @@ import Countdown from '../components/tuixiu/countdown.astro';
 ---
 
 <Layout
-  title="博退倒计时 - 袁博退休倒计时"
+  title="袁博退休倒计时 - 博Fans"
   description="距离腾讯云核心产品经理袁博（boyuan）退休还有多少时间？腾讯云lighthouse和DNSPod又该何去何从，让我们拭目以待。"
 >
   <Tuixiu>

--- a/apps/frontend-astro/src/pages/fans.astro
+++ b/apps/frontend-astro/src/pages/fans.astro
@@ -1,0 +1,21 @@
+---
+import '@mono/config-tailwind/global.css';
+import Layout from '../layouts/Layout.astro';
+import image2 from '../assets/image2.svg';
+---
+
+<Layout title="BoFans 页面" description="BoFans 简介与 image2 示例图。">
+  <main
+    class="mx-auto mt-10 max-w-3xl rounded-2xl bg-white/70 p-6 shadow-lg backdrop-blur"
+  >
+    <h1 class="mb-4 text-2xl font-bold">BoFans</h1>
+    <p class="mb-4 text-slate-700">
+      这是一个简洁的 fans 页面，先放一张 image2 示意图。
+    </p>
+    <img
+      src={image2.src}
+      alt="image2 示例图"
+      class="w-full rounded-xl border border-slate-200"
+    />
+  </main>
+</Layout>


### PR DESCRIPTION
### Motivation

- Provide a simple "BoFans" demo page with a sample illustration to showcase the fans section and an example image asset. 
- Include a lightweight SVG asset for use in the new page and other UI placeholders. 
- Adjust the existing `bo` page title to better match site branding.

### Description

- Added an SVG asset at `apps/frontend-astro/src/assets/image2.svg` that contains a gradient card with text and shapes. 
- Added a new page `apps/frontend-astro/src/pages/fans.astro` which imports global styles and `image2.svg` and renders a simple fans layout with the image. 
- Updated the title prop in `apps/frontend-astro/src/pages/bo.astro` from `"博退倒计时 - 袁博退休倒计时"` to `"袁博退休倒计时 - 博Fans"`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c8a4b1bc8331bd675c67bab06c52)