### PR TITLE
Rename and rewrite BO skill UI copy: '博哥口语 Skill' → '博说 Skill'

### DIFF
--- a/apps/frontend-astro/src/pages/bo/boge-skill.astro
+++ b/apps/frontend-astro/src/pages/bo/boge-skill.astro
@@ -13,8 +13,8 @@ const windowsInstaller = `${rawBaseUrl}/install-boge-oral-persona.ps1`;
 const commands = [
   {
     id: 'both-mac',
-    title: 'Codex + Claude Code · macOS / Linux',
-    note: '默认同时写入 ~/.codex/skills 和 ~/.claude/skills',
+    title: '用户目录安装 · macOS / Linux',
+    note: '安装到用户目录 skills',
     command: `bash -lc "$(curl -fsSL ${macInstaller})"`,
     tone: 'dark',
   },
@@ -27,8 +27,8 @@ const commands = [
   },
   {
     id: 'both-win',
-    title: 'Codex + Claude Code · Windows PowerShell',
-    note: '默认同时写入 .codex\\skills 和 .claude\\skills',
+    title: '用户目录安装 · Windows PowerShell',
+    note: '安装到用户目录 skills',
     command: `irm ${windowsInstaller} | iex`,
     tone: 'dark',
   },
@@ -55,25 +55,25 @@ const removeCommands = [
 ];
 
 const removePrompt =
-  '帮我删除博哥口语 Skill，Codex、Claude Code 和当前项目 .agents 里的都清掉。';
+  '帮我删除博说 Skill，把当前环境和项目 .agents 里的都清掉。';
 
 const agentRequests = [
   {
     id: 'agent-both',
     title: '装到自己的 agent',
-    prompt: `帮我安装博哥口语 Skill，Codex 和 Claude Code 都装好。安装源是 ${githubUrl}`,
+    prompt: `帮我安装博说 Skill。安装源是 ${githubUrl}`,
   },
   {
     id: 'agent-project',
     title: '装到当前项目',
-    prompt: `帮我把博哥口语 Skill 装进当前仓库的 .agents，让这个项目里的 agent 都能用。安装源是 ${githubUrl}`,
+    prompt: `帮我把博说 Skill 装进当前仓库的 .agents，让这个项目里的 agent 都能用。安装源是 ${githubUrl}`,
   },
 ];
 ---
 
 <Layout
-  title="安装博哥口语 Skill - 博Fans"
-  description="安装博哥口语 Skill 到 Codex、Claude Code 或项目 .agents 目录，并了解如何启用、关闭和删除。"
+  title="安装博说 Skill - 博Fans"
+  description="安装博说 Skill 到当前环境或项目 .agents 目录，并了解如何启用、关闭和删除。"
 >
   <main
     class="min-h-screen w-full overflow-x-hidden bg-[#f6f8ff] px-3 py-3 text-neutral-950 sm:px-4 sm:py-4"
@@ -126,7 +126,7 @@ const agentRequests = [
                 博哥：又是一个你妈嗨的一天我草泥马。
               </p>
               <p class="mt-2 text-sm leading-6 text-neutral-700">
-                人这辈子，怎么还得起床。💪
+                人这辈子，对吧
               </p>
             </div>
           </div>
@@ -162,12 +162,12 @@ const agentRequests = [
           <h1
             class="mt-3 text-2xl font-semibold leading-tight text-neutral-950 sm:text-3xl"
           >
-            安装博哥口语 Skill
+            安装博说 Skill
           </h1>
           <p
             class="mt-3 max-w-2xl text-sm leading-6 text-neutral-600 sm:text-base"
           >
-            装完以后，你跟 agent 说“用博哥说”“来点博哥味”“上点强度”，
+            装完以后，你跟 agent 说“让博哥说”“来点博哥味”“上点强度”，
             它就按这套口气回你；想关掉就说“正常说话”。
           </p>
         </header>
@@ -233,8 +233,7 @@ const agentRequests = [
               手动备用
             </h2>
             <p class="mt-2 text-sm leading-6 text-neutral-600">
-              agent 装不了的时候再用。默认命令会同时装 Codex 和 Claude Code；
-              `.agents` 命令用于项目共享。
+              agent 装不了的时候再用。`.agents` 命令用于项目共享。
             </p>
             <details class="mt-4 border border-neutral-950/10 bg-neutral-50">
               <summary
@@ -303,7 +302,7 @@ const agentRequests = [
               <div class="border border-neutral-950/10 bg-neutral-50 p-3">
                 <h3 class="font-mono text-xs text-[#0052D9]">启用</h3>
                 <ul class="mt-2 space-y-1 text-sm leading-6 text-neutral-700">
-                  <li>用博哥说</li>
+                  <li>让博哥说</li>
                   <li>来点博哥味</li>
                   <li>上点强度</li>
                   <li>博哥锐评一下</li>
@@ -312,7 +311,7 @@ const agentRequests = [
               <div class="border border-neutral-950/10 bg-neutral-50 p-3">
                 <h3 class="font-mono text-xs text-[#0052D9]">关闭</h3>
                 <ul class="mt-2 space-y-1 text-sm leading-6 text-neutral-700">
-                  <li>关闭博哥口吻</li>
+                  <li>让博哥别说了</li>
                   <li>正常说话</li>
                   <li>用正式语气</li>
                   <li>这句正常点</li>


### PR DESCRIPTION
### Motivation

- Update branding and user-facing copy for the BO skill page to use the new name "博说 Skill" and to clarify installation targets.
- Make installer descriptions less ambiguous about install targets and simplify the manual-install guidance.
- Improve a few sample phrases and prompts to better reflect the new naming and UX phrasing.

### Description

- Renamed UI strings from "博哥口语 Skill" / "博哥" to "博说 Skill" and adjusted page title and meta description in `apps/frontend-astro/src/pages/bo/boge-skill.astro`.
- Updated installer command titles and notes for macOS/Linux and Windows to say "用户目录安装" instead of referencing Codex/Claude Code; kept the `.agents` project install option unchanged.
- Simplified the manual-install help text and adjusted the agent prompt strings and the `removePrompt` message.
- Tweaked several on-page sample phrases (enable/disable commands and preview text) to match the renamed persona and updated wording.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166ebd92a483318c2aee9bda4d748c)